### PR TITLE
feat: blog.johnnyreilly.com -> johnnyreilly.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# [blog.johnnyreilly.com](https://blog.johnnyreilly.com)
+# [johnnyreilly.com](https://johnnyreilly.com)
 
 [![Static Web App - Build and Deploy 🏗️](https://github.com/johnnyreilly/blog.johnnyreilly.com/actions/workflows/build-and-deploy-static-web-app.yml/badge.svg)](https://github.com/johnnyreilly/blog.johnnyreilly.com/actions/workflows/build-and-deploy-static-web-app.yml)
 
-This repo contains the source code for John Reilly's blog. The blog can be found here: https://blog.johnnyreilly.com - it is built with [Docusaurus](https://docusaurus.io/).  
+This repo contains the source code for John Reilly's blog. The blog can be found here: <https://johnnyreilly.com> - it is built with [Docusaurus](https://docusaurus.io/).
 
 ## Running locally
 
@@ -30,7 +30,7 @@ yarn serve
 
 The blog is hosted on Azure Static Web Apps.
 
-[If you'd like to learn how we migrated to SWAs from GitHub Pages then read this post.](https://blog.johnnyreilly.com/2022/02/01/migrating-from-github-pages-to-azure-static-web-apps)
+[If you'd like to learn how we migrated to SWAs from GitHub Pages then read this post.](https://johnnyreilly.com/2022/02/01/migrating-from-github-pages-to-azure-static-web-apps)
 
 [We use GitHub Actions to publish.](.github/workflows/build-and-deploy-static-web-app.yml)
 
@@ -42,4 +42,4 @@ Auth between GitHub and Azure is handled by https://github.com/jongio/github-azu
 
 Historically this blog lived on Blogger; from 2012-2021. It only exists there for reference now; it can be found mouldering here: https://icanmakethiswork.blogspot.com
 
-If you're interested in how we migrated from Blogger to Docusaurus, then take a look at [our definitive guide to migrating from Blogger to Docusaurus](https://blog.johnnyreilly.com/definitive-guide-to-migrating-from-blogger-to-docusaurus)
+If you're interested in how we migrated from Blogger to Docusaurus, then take a look at [our definitive guide to migrating from Blogger to Docusaurus](https://johnnyreilly.com/definitive-guide-to-migrating-from-blogger-to-docusaurus)

--- a/blog-website/api/fallback/redirect.js
+++ b/blog-website/api/fallback/redirect.js
@@ -12,7 +12,7 @@ const yearMonthRegex = /\/\d\d\d\d\/(\d\d\/)?/;
 
 /**
  * Logic to handle redirects
- * @param {string} originalUrl eg https://blog.johnnyreilly.com/2019/06/typescript-webpack-you-down-with-pnp.html
+ * @param {string} originalUrl eg https://johnnyreilly.com/2019/06/typescript-webpack-you-down-with-pnp.html
  * @param {(log: string) => void} log
  * @returns {Redirect}
  */
@@ -23,6 +23,21 @@ function redirect(
   if (originalUrl) {
     // This URL has been proxied as there was no static file matching it.
     log(`x-ms-original-url: ${originalUrl}`);
+
+    if (originalUrl.startsWith('https://blog.johnnyreilly.com')) {
+      // redirect https://blog.johnnyreilly.com/whatever to https://johnnyreilly.com/whatever
+      const johnnyreillyUrl = originalUrl.replace(
+        'blog.johnnyreilly.com',
+        'johnnyreilly.com'
+      );
+
+      log(`Redirecting ${originalUrl} to ${johnnyreillyUrl}`);
+
+      return {
+        status: 301,
+        location: johnnyreillyUrl,
+      };
+    }
 
     const parsedURL = parseURL(originalUrl);
     // parsedURL.pathname example: /2019/06/typescript-webpack-you-down-with-pnp.html
@@ -41,7 +56,7 @@ function redirect(
     }
 
     if (parsedURL.pathname.startsWith('/feeds/posts/default')) {
-      // cater for https://blog.johnnyreilly.com/feeds/posts/default?alt=rss
+      // cater for https://johnnyreilly.com/feeds/posts/default?alt=rss
       const atomOrRss = parsedURL.search.includes('alt=rss')
         ? '/rss.xml'
         : '/atom.xml';
@@ -54,7 +69,7 @@ function redirect(
       };
     }
 
-    // cater for https://blog.johnnyreilly.com/search/label/uglifyjs
+    // cater for https://johnnyreilly.com/search/label/uglifyjs
     if (parsedURL.pathname.startsWith('/search/label/')) {
       const bloggerSearchRedirect =
         '/search?q=' + parsedURL.pathname.replace('/search/label/', '');
@@ -66,7 +81,7 @@ function redirect(
       };
     }
 
-    // cater for https://blog.johnnyreilly.com/2019/06/ or https://blog.johnnyreilly.com/2019/
+    // cater for https://johnnyreilly.com/2019/06/ or https://johnnyreilly.com/2019/
     if (parsedURL.pathname.match(yearMonthRegex)) {
       const bloggerArchiveRedirect = '/archive';
       log(`Redirecting ${originalUrl} to ${bloggerArchiveRedirect}`);

--- a/blog-website/api/fallback/redirect.test.js
+++ b/blog-website/api/fallback/redirect.test.js
@@ -3,7 +3,7 @@ const { describe, expect, test } = require('@jest/globals');
 const redirect = require('./redirect');
 
 describe('redirect', () => {
-  test('redirects should be matched', () => {
+  test('blog.johnnyreilly.com should be redirected to johnnyreilly.com', () => {
     const mockLogger = jest.fn();
 
     expect(
@@ -13,14 +13,36 @@ describe('redirect', () => {
       )
     ).toEqual({
       status: 301,
-      location: '/2013/12/04/simple-fading-in-and-out-using-css-transitions',
+      location:
+        'https://johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html',
     });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
       'x-ms-original-url: https://blog.johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://blog.johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html to /2013/12/04/simple-fading-in-and-out-using-css-transitions'
+      'Redirecting https://blog.johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html to https://johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html'
+    );
+  });
+
+  test('redirects should be matched', () => {
+    const mockLogger = jest.fn();
+
+    expect(
+      redirect(
+        'https://johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html',
+        mockLogger
+      )
+    ).toEqual({
+      status: 301,
+      location: '/2013/12/04/simple-fading-in-and-out-using-css-transitions',
+    });
+
+    expect(mockLogger.mock.calls[0][0]).toBe(
+      'x-ms-original-url: https://johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html'
+    );
+    expect(mockLogger.mock.calls[1][0]).toBe(
+      'Redirecting https://johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html to /2013/12/04/simple-fading-in-and-out-using-css-transitions'
     );
   });
 
@@ -29,7 +51,7 @@ describe('redirect', () => {
 
     expect(
       redirect(
-        'https://blog.johnnyreilly.com/feeds/posts/default?alt=rss',
+        'https://johnnyreilly.com/feeds/posts/default?alt=rss',
         mockLogger
       )
     ).toEqual({
@@ -38,10 +60,10 @@ describe('redirect', () => {
     });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
-      'x-ms-original-url: https://blog.johnnyreilly.com/feeds/posts/default?alt=rss'
+      'x-ms-original-url: https://johnnyreilly.com/feeds/posts/default?alt=rss'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://blog.johnnyreilly.com/feeds/posts/default?alt=rss to /rss.xml'
+      'Redirecting https://johnnyreilly.com/feeds/posts/default?alt=rss to /rss.xml'
     );
   });
 
@@ -49,17 +71,17 @@ describe('redirect', () => {
     const mockLogger = jest.fn();
 
     expect(
-      redirect('https://blog.johnnyreilly.com/feeds/posts/default', mockLogger)
+      redirect('https://johnnyreilly.com/feeds/posts/default', mockLogger)
     ).toEqual({
       status: 301,
       location: '/atom.xml',
     });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
-      'x-ms-original-url: https://blog.johnnyreilly.com/feeds/posts/default'
+      'x-ms-original-url: https://johnnyreilly.com/feeds/posts/default'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://blog.johnnyreilly.com/feeds/posts/default to /atom.xml'
+      'Redirecting https://johnnyreilly.com/feeds/posts/default to /atom.xml'
     );
   });
 
@@ -67,56 +89,49 @@ describe('redirect', () => {
     const mockLogger = jest.fn();
 
     expect(
-      redirect(
-        'https://blog.johnnyreilly.com/search/label/uglifyjs',
-        mockLogger
-      )
+      redirect('https://johnnyreilly.com/search/label/uglifyjs', mockLogger)
     ).toEqual({
       status: 301,
       location: '/search?q=uglifyjs',
     });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
-      'x-ms-original-url: https://blog.johnnyreilly.com/search/label/uglifyjs'
+      'x-ms-original-url: https://johnnyreilly.com/search/label/uglifyjs'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://blog.johnnyreilly.com/search/label/uglifyjs to /search?q=uglifyjs'
+      'Redirecting https://johnnyreilly.com/search/label/uglifyjs to /search?q=uglifyjs'
     );
   });
 
   test('blogger archive year/month redirects should be handled', () => {
     const mockLogger = jest.fn();
 
-    expect(
-      redirect('https://blog.johnnyreilly.com/2020/12/', mockLogger)
-    ).toEqual({
+    expect(redirect('https://johnnyreilly.com/2020/12/', mockLogger)).toEqual({
       status: 301,
       location: '/archive',
     });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
-      'x-ms-original-url: https://blog.johnnyreilly.com/2020/12/'
+      'x-ms-original-url: https://johnnyreilly.com/2020/12/'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://blog.johnnyreilly.com/2020/12/ to /archive'
+      'Redirecting https://johnnyreilly.com/2020/12/ to /archive'
     );
   });
 
   test('blogger archive year redirects should be handled', () => {
     const mockLogger = jest.fn();
 
-    expect(redirect('https://blog.johnnyreilly.com/2020/', mockLogger)).toEqual(
-      {
-        status: 301,
-        location: '/archive',
-      }
-    );
+    expect(redirect('https://johnnyreilly.com/2020/', mockLogger)).toEqual({
+      status: 301,
+      location: '/archive',
+    });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
-      'x-ms-original-url: https://blog.johnnyreilly.com/2020/'
+      'x-ms-original-url: https://johnnyreilly.com/2020/'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://blog.johnnyreilly.com/2020/ to /archive'
+      'Redirecting https://johnnyreilly.com/2020/ to /archive'
     );
   });
 
@@ -136,19 +151,19 @@ describe('redirect', () => {
   test('no explicit redirect should redirect to 404 with path in query', () => {
     const mockLogger = jest.fn();
 
-    expect(
-      redirect('https://blog.johnnyreilly.com/robots.txt', mockLogger)
-    ).toEqual({
-      status: 302,
-      location:
-        '/404?originalUrl=https%3A%2F%2Fblog.johnnyreilly.com%2Frobots.txt',
-    });
+    expect(redirect('https://johnnyreilly.com/robots.txt', mockLogger)).toEqual(
+      {
+        status: 302,
+        location:
+          '/404?originalUrl=https%3A%2F%2Fjohnnyreilly.com%2Frobots.txt',
+      }
+    );
 
     expect(mockLogger.mock.calls[0][0]).toBe(
-      'x-ms-original-url: https://blog.johnnyreilly.com/robots.txt'
+      'x-ms-original-url: https://johnnyreilly.com/robots.txt'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://blog.johnnyreilly.com/robots.txt to /404?originalUrl=https%3A%2F%2Fblog.johnnyreilly.com%2Frobots.txt as no explicit redirect exists'
+      'Redirecting https://johnnyreilly.com/robots.txt to /404?originalUrl=https%3A%2F%2Fjohnnyreilly.com%2Frobots.txt as no explicit redirect exists'
     );
   });
 });

--- a/blog-website/blog/authors.yml
+++ b/blog-website/blog/authors.yml
@@ -1,4 +1,4 @@
 johnnyreilly:
   name: John Reilly
   url: https://twitter.com/johnny_reilly
-  image_url: https://blog.johnnyreilly.com/img/profile.jpg
+  image_url: https://johnnyreilly.com/img/profile.jpg

--- a/blog-website/docusaurus.config.js
+++ b/blog-website/docusaurus.config.js
@@ -12,8 +12,8 @@ const url = 'https://johnnyreilly.com';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'I CAN MAKE THIS WORK',
-  tagline: 'The blog of johnnyreilly ❤️🌻',
+  title: 'johnnyreilly',
+  tagline: "Hi! I'm John Reilly - welcome! ❤️🌻",
   url,
   baseUrl: '/',
   onBrokenLinks: 'throw',
@@ -74,12 +74,12 @@ const config = {
           feedOptions: {
             type: ['rss', 'atom'],
             title: 'I CAN MAKE THIS WORK',
-            description: 'The blog of johnnyreilly ❤️🌻',
+            description: 'The blog of John Reilly ❤️🌻',
             language: 'en',
             copyright: `Copyright © 2012 - ${new Date().getFullYear()} John Reilly.`,
           },
           blogTitle: 'I CAN MAKE THIS WORK',
-          blogDescription: 'The blog of johnnyreilly',
+          blogDescription: 'The blog of John Reilly ❤️🌻',
           /**
            * Number of blog post elements to show in the blog sidebar
            * 'ALL' to show all blog posts
@@ -263,9 +263,9 @@ const config = {
       // Cannot be SVGs. Can be external URLs too.
       image: 'img/profile.jpg',
       navbar: {
-        title: 'I CAN MAKE THIS WORK',
+        title: 'John Reilly ❤️🌻',
         logo: {
-          alt: 'I CAN MAKE THIS WORK',
+          alt: 'Profile picture of John Reilly',
           src: 'img/profile-64x64.jpg',
           width: 32,
           height: 32,

--- a/blog-website/docusaurus.config.js
+++ b/blog-website/docusaurus.config.js
@@ -263,7 +263,7 @@ const config = {
       // Cannot be SVGs. Can be external URLs too.
       image: 'img/profile.jpg',
       navbar: {
-        title: 'John Reilly ❤️🌻',
+        title: 'John Reilly',
         logo: {
           alt: 'Profile picture of John Reilly',
           src: 'img/profile-64x64.jpg',

--- a/blog-website/docusaurus.config.js
+++ b/blog-website/docusaurus.config.js
@@ -73,12 +73,12 @@ const config = {
             : [],
           feedOptions: {
             type: ['rss', 'atom'],
-            title: 'I CAN MAKE THIS WORK',
+            title: 'johnnyreilly',
             description: 'The blog of John Reilly ❤️🌻',
             language: 'en',
             copyright: `Copyright © 2012 - ${new Date().getFullYear()} John Reilly.`,
           },
-          blogTitle: 'I CAN MAKE THIS WORK',
+          blogTitle: 'johnnyreilly',
           blogDescription: 'The blog of John Reilly ❤️🌻',
           /**
            * Number of blog post elements to show in the blog sidebar
@@ -323,6 +323,10 @@ const config = {
           {
             title: 'Feeds',
             items: [
+              {
+                label: 'Blog source code on GitHub',
+                href: 'https://github.com/johnnyreilly/blog.johnnyreilly.com',
+              },
               {
                 label: 'RSS',
                 href: 'https://johnnyreilly.com/rss.xml',

--- a/blog-website/docusaurus.config.js
+++ b/blog-website/docusaurus.config.js
@@ -73,12 +73,12 @@ const config = {
             : [],
           feedOptions: {
             type: ['rss', 'atom'],
-            title: 'johnnyreilly',
+            title: 'I CAN MAKE THIS WORK',
             description: 'The blog of John Reilly ❤️🌻',
             language: 'en',
             copyright: `Copyright © 2012 - ${new Date().getFullYear()} John Reilly.`,
           },
-          blogTitle: 'johnnyreilly',
+          blogTitle: 'I CAN MAKE THIS WORK',
           blogDescription: 'The blog of John Reilly ❤️🌻',
           /**
            * Number of blog post elements to show in the blog sidebar

--- a/blog-website/docusaurus.config.js
+++ b/blog-website/docusaurus.config.js
@@ -8,7 +8,7 @@ const fontaine = require('fontaine');
 const lightCodeTheme = require('prism-react-renderer/themes/nightOwl'); //github
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
-const url = 'https://blog.johnnyreilly.com';
+const url = 'https://johnnyreilly.com';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -106,7 +106,7 @@ const config = {
       tagName: 'link',
       attributes: {
         rel: 'preload',
-        href: 'https://blog.johnnyreilly.com/fonts/Poppins-Regular.woff2',
+        href: 'https://johnnyreilly.com/fonts/Poppins-Regular.woff2',
         as: 'font',
         type: 'font/woff2',
         crossorigin: 'anonymous',
@@ -117,7 +117,7 @@ const config = {
       tagName: 'link',
       attributes: {
         rel: 'preload',
-        href: 'https://blog.johnnyreilly.com/fonts/Poppins-Bold.woff2',
+        href: 'https://johnnyreilly.com/fonts/Poppins-Bold.woff2',
         as: 'font',
         type: 'font/woff2',
         crossorigin: 'anonymous',
@@ -325,11 +325,11 @@ const config = {
             items: [
               {
                 label: 'RSS',
-                href: 'https://blog.johnnyreilly.com/rss.xml',
+                href: 'https://johnnyreilly.com/rss.xml',
               },
               {
                 label: 'Atom',
-                href: 'https://blog.johnnyreilly.com/atom.xml',
+                href: 'https://johnnyreilly.com/atom.xml',
               },
             ],
           },

--- a/blog-website/i18n/en/code.json
+++ b/blog-website/i18n/en/code.json
@@ -16,7 +16,7 @@
     "description": "The page & hero title of the blog archive page"
   },
   "theme.blog.archive.description": {
-    "message": "Historic Posts",
+    "message": "I can make this work - historic posts",
     "description": "The page & hero description of the blog archive page"
   },
   "theme.BackToTopButton.buttonAriaLabel": {

--- a/blog-website/package.json
+++ b/blog-website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "blog.johnnyreilly.com",
+  "name": "johnnyreilly.com",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/blog-website/src/css/custom.css
+++ b/blog-website/src/css/custom.css
@@ -23,7 +23,7 @@
 
 @font-face {
   font-family: 'Poppins';
-  src: url('https://blog.johnnyreilly.com/fonts/Poppins-Regular.woff2');
+  src: url('https://johnnyreilly.com/fonts/Poppins-Regular.woff2');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -31,7 +31,7 @@
 
 @font-face {
   font-family: 'Poppins';
-  src: url('https://blog.johnnyreilly.com/fonts/Poppins-Bold.woff2');
+  src: url('https://johnnyreilly.com/fonts/Poppins-Bold.woff2');
   font-weight: 700;
   font-style: normal;
   font-display: swap;

--- a/blog-website/src/css/custom.css
+++ b/blog-website/src/css/custom.css
@@ -47,3 +47,8 @@
 html[data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
 }
+
+.navbar__brand::after {
+  margin-left: 0.2em;
+  content: '❤️🌻';
+}

--- a/blog-website/src/css/custom.css
+++ b/blog-website/src/css/custom.css
@@ -52,3 +52,7 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
   margin-left: 0.2em;
   content: '❤️🌻';
 }
+
+.navbar__title {
+  font-size: 1.2em;
+}

--- a/blog-website/src/pages/about.js
+++ b/blog-website/src/pages/about.js
@@ -79,12 +79,12 @@ function About() {
                   </p>
 
                   <p>
-                    I answer to "John", but online I'm johnnyreilly or similar
-                    for the most part; mostly because way back when I was first
-                    getting online, someone else had nabbed "JohnReilly" long
-                    before I hove into view. And it turns out to be useful
+                    I answer to "John", but online I'm johnnyreilly or similar;
+                    mostly because way back when I was
+                    getting online, someone else had nabbed "JohnReilly" first. 
+                    And it turns out to be useful
                     differentiation from the movie star John Reilly that{' '}
-                    <em>isn't</em> me. (Look him up)
+                    <em>isn't</em> me. (Look him up - he's great!)
                   </p>
 
                   <p>

--- a/blog-website/src/pages/about.js
+++ b/blog-website/src/pages/about.js
@@ -19,8 +19,8 @@ function About() {
     name: 'John Reilly',
     alternateName: 'Johnny Reilly',
     description: 'MacGyver turned Dev',
-    url: 'https://blog.johnnyreilly.com',
-    image: 'https://blog.johnnyreilly.com/img/profile.jpg',
+    url: 'https://johnnyreilly.com',
+    image: 'https://johnnyreilly.com/img/profile.jpg',
     address: {
       '@type': 'PostalAddress',
       streetAddress: 'Twickenham',
@@ -30,10 +30,10 @@ function About() {
     email: 'johnny_reilly@hotmail.com',
     birthPlace: 'Bristol',
     sameAs: [
+      'https://fosstodon.org/@johnny_reilly',
       'https://twitter.com/johnny_reilly',
       'https://github.com/johnnyreilly',
-      'https://fosstodon.org/@johnny_reilly',
-      'https://https://stackoverflow.com/users/761388/john-reilly',
+      'https://stackoverflow.com/users/761388/john-reilly',
       'https://blog.logrocket.com/author/johnreilly/',
       'https://polywork.com/johnnyreilly',
     ],

--- a/blog-website/src/pages/about.js
+++ b/blog-website/src/pages/about.js
@@ -80,10 +80,9 @@ function About() {
 
                   <p>
                     I answer to "John", but online I'm johnnyreilly or similar;
-                    mostly because way back when I was
-                    getting online, someone else had nabbed "JohnReilly" first. 
-                    And it turns out to be useful
-                    differentiation from the movie star John Reilly that{' '}
+                    mostly because way back when I was getting online, someone
+                    else had nabbed "JohnReilly" first. And it turns out to be
+                    useful differentiation from the movie star John Reilly that{' '}
                     <em>isn't</em> me. (Look him up - he's great!)
                   </p>
 
@@ -102,12 +101,15 @@ function About() {
 
                   <h3>What is this?</h3>
                   <p>
-                    The meanderings and ramblings of a software engineer. A
-                    great deal of "here's how I solved X".
-                  </p>
-                  <p>
-                    If you were wondering, the "I can make this work" title of
-                    this blog started life as a pun on{' '}
+                    This started life{' '}
+                    <a
+                      href="https://icanmakethiswork.blogspot.com/"
+                      rel="noopener noreferrer nofollow"
+                      target="_blank"
+                    >
+                      on Blogger with the title "I can make this work"
+                    </a>{' '}
+                    - which was a pun on{' '}
                     <a
                       href="http://en.wikipedia.org/wiki/ICANN"
                       target="_blank"
@@ -115,6 +117,11 @@ function About() {
                       ICANN
                     </a>
                     . Not, if I'm honest, the finest joke in the world.
+                  </p>
+                  <p>
+                    These days it's mostly the blog of an open source software
+                    engineer. A great deal of "here's how I solved X". Some
+                    talks I've given as well. Whatever I feel like putting out.
                   </p>
                 </div>
 

--- a/blog-website/src/pages/about.js
+++ b/blog-website/src/pages/about.js
@@ -79,10 +79,11 @@ function About() {
                   </p>
 
                   <p>
-                    I answer to "John", but online I'm johnnyreilly or similar;
-                    mostly because way back when I was getting online, someone
-                    else had nabbed "JohnReilly" first. And it turns out to be
-                    useful differentiation from the movie star John Reilly that{' '}
+                    I answer to "John", but online I'm "johnnyreilly",
+                    "johnny_reilly" or similar. Mostly because way back when I
+                    was getting online, someone else had nabbed "johnreilly"
+                    first. In retrospect it turns out to be useful
+                    differentiation from the actor John C. Reilly that very much{' '}
                     <em>isn't</em> me. (Look him up - he's great!)
                   </p>
 
@@ -91,12 +92,9 @@ function About() {
                     <a href="https://reillysontour.blogspot.com/">
                       travel blog(ish)
                     </a>{' '}
-                    as well.
-                  </p>
-
-                  <p>
-                    You can{' '}
-                    <a href="mailto:johnny_reilly@hotmail.com">email me</a>.
+                    as well. You can{' '}
+                    <a href="mailto:johnny_reilly@hotmail.com">email me here</a>
+                    .
                   </p>
 
                   <h3>What is this?</h3>
@@ -121,7 +119,8 @@ function About() {
                   <p>
                     These days it's mostly the blog of an open source software
                     engineer. A great deal of "here's how I solved X". Some
-                    talks I've given as well. Whatever I feel like putting out.
+                    talks I've given as well. Essentially, whatever I feel like
+                    putting out.
                   </p>
                 </div>
 

--- a/blog-website/src/pages/about.js
+++ b/blog-website/src/pages/about.js
@@ -53,7 +53,7 @@ function About() {
       >
         <header className={clsx('hero hero--primary', styles.heroBanner)}>
           <div className="container">
-            <h1 className="hero__title">{siteConfig.title}</h1>
+            {/* <h1 className="hero__title">{siteConfig.title}</h1> */}
             <div className="text--center">
               <img
                 src={imgUrl}
@@ -61,13 +61,63 @@ function About() {
                 alt="johnnyreilly profile picture"
               />
             </div>
-            <p className="hero__subtitle">{siteConfig.tagline}</p>
+            <h1 className="hero__title">{siteConfig.tagline}</h1>
+            {/* <p className="hero__subtitle">{siteConfig.tagline}</p> */}
           </div>
         </header>
         <main>
           <section className={styles.features}>
             <div className="container">
               <div className="row">
+                <div className={clsx('col col--6', styles.feature)}>
+                  <h3>Who am I?</h3>
+                  <p>
+                    I'm an engineer, writer, hedge chopper, father, food
+                    botherer, Christian and husband to the most wonderful
+                    Geordie wife there ever was! I live in London / Twickenham.
+                    I was born in Bristol and I was raised in Fleet.
+                  </p>
+
+                  <p>
+                    I answer to "John", but online I'm johnnyreilly or similar
+                    for the most part; mostly because way back when I was first
+                    getting online, someone else had nabbed "JohnReilly" long
+                    before I hove into view. And it turns out to be useful
+                    differentiation from the movie star John Reilly that{' '}
+                    <em>isn't</em> me. (Look him up)
+                  </p>
+
+                  <p>
+                    I write the occasional{' '}
+                    <a href="https://reillysontour.blogspot.com/">
+                      travel blog(ish)
+                    </a>{' '}
+                    as well.
+                  </p>
+
+                  <p>
+                    You can{' '}
+                    <a href="mailto:johnny_reilly@hotmail.com">email me</a>.
+                  </p>
+
+                  <h3>What is this?</h3>
+                  <p>
+                    The meanderings and ramblings of a software engineer. A
+                    great deal of "here's how I solved X".
+                  </p>
+                  <p>
+                    If you were wondering, the "I can make this work" title of
+                    this blog started life as a pun on{' '}
+                    <a
+                      href="http://en.wikipedia.org/wiki/ICANN"
+                      target="_blank"
+                    >
+                      ICANN
+                    </a>
+                    . Not, if I'm honest, the finest joke in the world.
+                  </p>
+                </div>
+
                 <div className={clsx('col col--6', styles.feature)}>
                   <h3>What do I do?</h3>
                   <p>
@@ -125,44 +175,6 @@ function About() {
                     <a href="https://blog.logrocket.com/author/johnreilly/">
                       LogRocket
                     </a>
-                  </p>
-                </div>
-
-                <div className={clsx('col col--6', styles.feature)}>
-                  <h3>What is this?</h3>
-                  <p>
-                    The meanderings and ramblings of a software engineer. If you
-                    were wondering, the slightly egotistical-sounding title of
-                    this blog started life as a pun on{' '}
-                    <a
-                      href="http://en.wikipedia.org/wiki/ICANN"
-                      target="_blank"
-                    >
-                      ICANN
-                    </a>
-                    . Not, if I'm honest, the finest joke in the world but I
-                    haven't yet thought of a better name and so here we are...
-                  </p>
-
-                  <h3>Who am I?</h3>
-                  <p>
-                    Long-time Londoner, born in Bristol and raised in Fleet.
-                    Developer, writer, hedge chopper extraordinaire, father,
-                    food botherer, Christian and husband to the most wonderful
-                    Geordie wife there ever was!
-                  </p>
-
-                  <p>
-                    I write the occasional{' '}
-                    <a href="https://reillysontour.blogspot.com/">
-                      travel blog(ish)
-                    </a>{' '}
-                    as well.
-                  </p>
-
-                  <p>
-                    You can{' '}
-                    <a href="mailto:johnny_reilly@hotmail.com">email me</a>.
                   </p>
                 </div>
               </div>

--- a/blog-website/static/manifest.json
+++ b/blog-website/static/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "I CAN MAKE THIS WORK",
-  "short_name": "I CAN MAKE THIS WORK",
+  "name": "johnnyreilly",
+  "short_name": "johnnyreilly",
   "theme_color": "#3578e5",
   "background_color": "#424242",
   "display": "standalone",

--- a/blog-website/staticwebapp.config.json
+++ b/blog-website/staticwebapp.config.json
@@ -37,7 +37,7 @@
     }
   ],
   "globalHeaders": {
-    "content-security-policy": "default-src https: 'unsafe-eval' 'unsafe-inline'; object-src 'none'; script-src 'self' https://www.googleanalytics.com https://www.google-analytics.com https://www.googleoptimize.com https://www.googletagmanager.com https://gist.github.com 'unsafe-inline'; img-src 'self' data: https: https://blog.johnnyreilly.com https://www.google-analytics.com https://www.googletagmanager.com https://dev.to https://res.cloudinary.com; font-src 'self' https://blog.johnnyreilly.com",
+    "content-security-policy": "default-src https: 'unsafe-eval' 'unsafe-inline'; object-src 'none'; script-src 'self' https://www.googleanalytics.com https://www.google-analytics.com https://www.googleoptimize.com https://www.googletagmanager.com https://gist.github.com 'unsafe-inline'; img-src 'self' data: https: https://johnnyreilly.com https://blog.johnnyreilly.com https://www.google-analytics.com https://www.googletagmanager.com https://dev.to https://res.cloudinary.com; font-src 'self' https://johnnyreilly.com https://blog.johnnyreilly.com",
     "X-Clacks-Overhead": "GNU Terry Pratchett",
     "Access-Control-Allow-Origin": "*"
   },

--- a/from-docusaurus-to-devto/index.ts
+++ b/from-docusaurus-to-devto/index.ts
@@ -7,7 +7,7 @@ import {
   devtoApiClientFactory,
 } from './devtoApiClient';
 
-const rootUrl = 'https://blog.johnnyreilly.com';
+const rootUrl = 'https://johnnyreilly.com';
 const rootGitHubUrl =
   'https://raw.githubusercontent.com/johnnyreilly/blog.johnnyreilly.com/main/blog-website/blog/';
 const docusaurusBlogDirectory = '../blog-website/blog';

--- a/infra/staticWebApp.bicep
+++ b/infra/staticWebApp.bicep
@@ -11,7 +11,6 @@ param appInsightsInstrumentationKey string
 param appInsightsConnectionString string
 
 var tagsWithHiddenLinks = union({
-  // 'hidden-link: /app-insights-resource-id': '/subscriptions/26178455-cfd9-4d36-bab5-35896b6d2dd1/resourceGroups/rg-blog-johnnyreilly-com/providers/microsoft.insights/components/blog.johnnyreilly.com'
   'hidden-link: /app-insights-resource-id': appInsightsId
   'hidden-link: /app-insights-instrumentation-key': appInsightsInstrumentationKey
   'hidden-link: /app-insights-conn-string': appInsightsConnectionString

--- a/trim-xml/index.ts
+++ b/trim-xml/index.ts
@@ -7,7 +7,7 @@ import {
 } from './getGitLastUpdated';
 import { SitemapUrl, Sitemap, AtomFeed, RssItem, RssFeed } from './types';
 
-const rootUrl = 'https://blog.johnnyreilly.com';
+const rootUrl = 'https://johnnyreilly.com';
 
 async function enrichUrlsWithLastmod(
   filteredUrls: SitemapUrl[]


### PR DESCRIPTION
I'm planning to migrate from the URL of https://blog.johnnyreilly.com to https://johnnyreilly.com. This PR takes care of canonical URLs etc. 

A 302 redirect has been set up with CloudFlare - post merge of this PR that will be upgraded to a 301 (permanent).

There's lots of links on the internet to blog.johnnyreilly.com; I'll update those that can be updated manually to johnnyreilly.com.  I'll send PRs / emails etc to get the rest updated but the 301s should mean traffic is unaffected.

https://github.com/search?q=blog.johnnyreilly.com&type=code

This PR also dials down "I can make this work" in favour of "johnnyreilly"