### PR TITLE
feat: cross-env WEBPACK_URL_LOADER_LIMIT=0 no transform data

### DIFF
--- a/blog-website/package.json
+++ b/blog-website/package.json
@@ -7,7 +7,7 @@
     "funcBuild": "swa start build --api-location api",
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "cross-env URL_LOADER_LIMIT=0 docusaurus build",
+    "build": "cross-env WEBPACK_URL_LOADER_LIMIT=0 docusaurus build",
     "postbuild": "cd ../trim-xml && yarn && yarn start",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/blog-website/package.json
+++ b/blog-website/package.json
@@ -7,7 +7,7 @@
     "funcBuild": "swa start build --api-location api",
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "cross-env URL_LOADER_LIMIT=0 docusaurus build",
     "postbuild": "cd ../trim-xml && yarn && yarn start",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
@@ -38,9 +38,10 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.2.0",
     "@tsconfig/docusaurus": "1.0.6",
+    "cross-env": "^7.0.3",
     "fontaine": "0.2.3",
-    "typescript": "4.9.4",
-    "remark-cloudinary-docusaurus": "1.0.0"
+    "remark-cloudinary-docusaurus": "1.0.0",
+    "typescript": "4.9.4"
   },
   "browserslist": {
     "production": [

--- a/blog-website/yarn.lock
+++ b/blog-website/yarn.lock
@@ -3866,6 +3866,13 @@ cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@^3.0.4, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
@@ -3884,7 +3891,7 @@ cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.3:
+cross-spawn@^7.0.1, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
This PR disables using the url-loader to transform images into data URIs using the environment variable `WEBPACK_URL_LOADER_LIMIT=0`

See https://github.com/facebook/docusaurus/issues/5493
And https://v4.webpack.js.org/loaders/url-loader/#limit

The top image in this post should *not* use data URIs with this change in place: https://thankful-sky-0bfc7e803-397.westeurope.1.azurestaticapps.net/2021/03/20/bicep-meet-azure-pipelines