### PR TITLE
Redirect URLs but once

### DIFF
--- a/.github/workflows/build-and-deploy-static-web-app.yml
+++ b/.github/workflows/build-and-deploy-static-web-app.yml
@@ -50,43 +50,45 @@ jobs:
           DEPLOYMENT_NAME="${REF_SHA////-}"
           echo "DEPLOYMENT_NAME=$DEPLOYMENT_NAME" >> $GITHUB_OUTPUT
 
-      - name: Infra changes 📝
-        id: static_web_app_what_if
-        if: github.event_name == 'pull_request'
-        uses: azure/CLI@v1
-        with:
-          inlineScript: |
-            az deployment group what-if \
-              --resource-group ${{ env.RESOURCE_GROUP }} \
-              --name "${{ steps.deployment_name.outputs.DEPLOYMENT_NAME }}" \
-              --template-file ./infra/main.bicep \
-              --parameters \
-                  branch='main' \
-                  location='${{ env.LOCATION }}' \
-                  staticWebAppName='${{ env.STATICWEBAPPNAME }}' \
-                  tags='${{ env.TAGS }}' \
-                  repositoryToken='${{ secrets.WORKFLOW_TOKEN }}' \
-                  rootCustomDomainName='${{ env.ROOTCUSTOMDOMAINNAME }}' \
-                  blogCustomDomainName='${{ env.BLOGCUSTOMDOMAINNAME }}'
+      # Commented out whilst this issue exists: https://github.com/Azure/azure-cli/issues/25710
 
-      - name: Deploy infra 🔧
-        id: static_web_app_deploy
-        if: github.event_name != 'pull_request'
-        uses: azure/CLI@v1
-        with:
-          inlineScript: |
-            az deployment group create \
-              --resource-group ${{ env.RESOURCE_GROUP }} \
-              --name "${{ steps.deployment_name.outputs.DEPLOYMENT_NAME }}" \
-              --template-file ./infra/main.bicep \
-              --parameters \
-                  branch='main' \
-                  location='${{ env.LOCATION }}' \
-                  staticWebAppName='${{ env.STATICWEBAPPNAME }}' \
-                  tags='${{ env.TAGS }}' \
-                  repositoryToken='${{ secrets.WORKFLOW_TOKEN }}' \
-                  rootCustomDomainName='${{ env.ROOTCUSTOMDOMAINNAME }}' \
-                  blogCustomDomainName='${{ env.BLOGCUSTOMDOMAINNAME }}'
+      # - name: Infra - detect changes 📝
+      #   id: static_web_app_what_if
+      #   if: github.event_name == 'pull_request'
+      #   uses: azure/CLI@v1
+      #   with:
+      #     inlineScript: |
+      #       az deployment group what-if \
+      #         --resource-group ${{ env.RESOURCE_GROUP }} \
+      #         --name "${{ steps.deployment_name.outputs.DEPLOYMENT_NAME }}" \
+      #         --template-file ./infra/main.bicep \
+      #         --parameters \
+      #             branch='main' \
+      #             location='${{ env.LOCATION }}' \
+      #             staticWebAppName='${{ env.STATICWEBAPPNAME }}' \
+      #             tags='${{ env.TAGS }}' \
+      #             repositoryToken='${{ secrets.WORKFLOW_TOKEN }}' \
+      #             rootCustomDomainName='${{ env.ROOTCUSTOMDOMAINNAME }}' \
+      #             blogCustomDomainName='${{ env.BLOGCUSTOMDOMAINNAME }}'
+
+      # - name: Infra - deploy 🔧
+      #   id: static_web_app_deploy
+      #   if: github.event_name != 'pull_request'
+      #   uses: azure/CLI@v1
+      #   with:
+      #     inlineScript: |
+      #       az deployment group create \
+      #         --resource-group ${{ env.RESOURCE_GROUP }} \
+      #         --name "${{ steps.deployment_name.outputs.DEPLOYMENT_NAME }}" \
+      #         --template-file ./infra/main.bicep \
+      #         --parameters \
+      #             branch='main' \
+      #             location='${{ env.LOCATION }}' \
+      #             staticWebAppName='${{ env.STATICWEBAPPNAME }}' \
+      #             tags='${{ env.TAGS }}' \
+      #             repositoryToken='${{ secrets.WORKFLOW_TOKEN }}' \
+      #             rootCustomDomainName='${{ env.ROOTCUSTOMDOMAINNAME }}' \
+      #             blogCustomDomainName='${{ env.BLOGCUSTOMDOMAINNAME }}'
 
       - name: Get preview URL 📝
         id: static_web_app_preview_url

--- a/blog-website/api/fallback/redirect.js
+++ b/blog-website/api/fallback/redirect.js
@@ -9,6 +9,7 @@ const routes = require('./redirects');
  */
 
 const yearMonthRegex = /\/\d\d\d\d\/(\d\d\/)?/;
+const baseUrl = 'https://johnnyreilly.com';
 
 /**
  * Logic to handle redirects
@@ -24,22 +25,16 @@ function redirect(
     // This URL has been proxied as there was no static file matching it.
     log(`x-ms-original-url: ${originalUrl}`);
 
-    if (originalUrl.startsWith('https://blog.johnnyreilly.com')) {
-      // redirect https://blog.johnnyreilly.com/whatever to https://johnnyreilly.com/whatever
-      const johnnyreillyUrl = originalUrl.replace(
-        'blog.johnnyreilly.com',
-        'johnnyreilly.com'
-      );
+    // we will redirect https://blog.johnnyreilly.com/... to https://johnnyreilly.com/...
+    const isBlogJohnnyReillyCom = originalUrl.startsWith(
+      'https://blog.johnnyreilly.com'
+    );
 
-      log(`Redirecting ${originalUrl} to ${johnnyreillyUrl}`);
-
-      return {
-        status: 301,
-        location: johnnyreillyUrl,
-      };
-    }
-
-    const parsedURL = parseURL(originalUrl);
+    const parsedURL = parseURL(
+      isBlogJohnnyReillyCom
+        ? originalUrl.replace('blog.johnnyreilly.com', 'johnnyreilly.com')
+        : originalUrl
+    );
     // parsedURL.pathname example: /2019/06/typescript-webpack-you-down-with-pnp.html
 
     const matchedRoute = routes.find((route) =>
@@ -47,12 +42,11 @@ function redirect(
     );
 
     if (matchedRoute) {
-      log(`Redirecting ${originalUrl} to ${matchedRoute.redirect}`);
-
-      return {
-        status: 301,
-        location: matchedRoute.redirect,
-      };
+      return redirect301({
+        log,
+        originalUrl,
+        redirectUrl: matchedRoute.redirect,
+      });
     }
 
     if (parsedURL.pathname.startsWith('/feeds/posts/default')) {
@@ -61,35 +55,29 @@ function redirect(
         ? '/rss.xml'
         : '/atom.xml';
 
-      log(`Redirecting ${originalUrl} to ${atomOrRss}`);
-
-      return {
-        status: 301,
-        location: atomOrRss,
-      };
+      return redirect301({ log, originalUrl, redirectUrl: atomOrRss });
     }
 
     // cater for https://johnnyreilly.com/search/label/uglifyjs
     if (parsedURL.pathname.startsWith('/search/label/')) {
       const bloggerSearchRedirect =
         '/search?q=' + parsedURL.pathname.replace('/search/label/', '');
-      log(`Redirecting ${originalUrl} to ${bloggerSearchRedirect}`);
 
-      return {
-        status: 301,
-        location: bloggerSearchRedirect,
-      };
+      return redirect301({
+        log,
+        originalUrl,
+        redirectUrl: bloggerSearchRedirect,
+      });
     }
 
     // cater for https://johnnyreilly.com/2019/06/ or https://johnnyreilly.com/2019/
     if (parsedURL.pathname.match(yearMonthRegex)) {
       const bloggerArchiveRedirect = '/archive';
-      log(`Redirecting ${originalUrl} to ${bloggerArchiveRedirect}`);
-
-      return {
-        status: 301,
-        location: bloggerArchiveRedirect,
-      };
+      return redirect301({
+        log,
+        originalUrl,
+        redirectUrl: bloggerArchiveRedirect,
+      });
     }
 
     // cater for https://johnnyreilly.com/assets/images/auth0-enable-password-grant-type-d1ee245b0e059914635e5dada9942ab4.png
@@ -104,19 +92,18 @@ function redirect(
       );
 
       if (likelyImageRedirect) {
-        log(`Redirecting ${originalUrl} to ${likelyImageRedirect}`);
-
-        return {
-          status: 301,
-          location: likelyImageRedirect,
-        };
+        return redirect301({
+          log,
+          originalUrl,
+          redirectUrl: likelyImageRedirect,
+        });
       }
     }
   }
 
   const location = originalUrl
-    ? `/404?originalUrl=${encodeURIComponent(originalUrl)}`
-    : '/404';
+    ? `${baseUrl}/404?originalUrl=${encodeURIComponent(originalUrl)}`
+    : `${baseUrl}/404`;
 
   log(
     `Redirecting ${originalUrl} to ${location} as no explicit redirect exists`
@@ -125,6 +112,28 @@ function redirect(
   return {
     status: 302,
     location,
+  };
+}
+
+/**
+ * @typedef {Object} Redirect301Params
+ * @property {string} redirectUrl
+ * @property {(log: string) => void} log
+ * @property {string} originalUrl
+ */
+
+/**
+ *
+ * @param {Redirect301Params} redirect301Params
+ * @returns
+ */
+function redirect301({ redirectUrl, log, originalUrl }) {
+  const redirectUrlWithBase = `${baseUrl}${redirectUrl}`;
+  log(`Redirecting ${originalUrl} to ${redirectUrlWithBase}`);
+
+  return {
+    status: 301,
+    location: redirectUrlWithBase,
   };
 }
 

--- a/blog-website/api/fallback/redirect.test.js
+++ b/blog-website/api/fallback/redirect.test.js
@@ -14,14 +14,36 @@ describe('redirect', () => {
     ).toEqual({
       status: 301,
       location:
-        'https://johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html',
+        'https://johnnyreilly.com/simple-fading-in-and-out-using-css-transitions',
     });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
       'x-ms-original-url: https://blog.johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://blog.johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html to https://johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html'
+      'Redirecting https://blog.johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html to https://johnnyreilly.com/simple-fading-in-and-out-using-css-transitions'
+    );
+  });
+
+  test('blog.johnnyreilly.com should be redirected to matches where possible', () => {
+    const mockLogger = jest.fn();
+
+    expect(
+      redirect(
+        'https://blog.johnnyreilly.com/2021/01/30/aspnet-serilog-and-application-insights',
+        mockLogger
+      )
+    ).toEqual({
+      status: 301,
+      location:
+        'https://johnnyreilly.com/aspnet-serilog-and-application-insights',
+    });
+
+    expect(mockLogger.mock.calls[0][0]).toBe(
+      'x-ms-original-url: https://blog.johnnyreilly.com/2021/01/30/aspnet-serilog-and-application-insights'
+    );
+    expect(mockLogger.mock.calls[1][0]).toBe(
+      'Redirecting https://blog.johnnyreilly.com/2021/01/30/aspnet-serilog-and-application-insights to https://johnnyreilly.com/aspnet-serilog-and-application-insights'
     );
   });
 
@@ -35,14 +57,15 @@ describe('redirect', () => {
       )
     ).toEqual({
       status: 301,
-      location: '/simple-fading-in-and-out-using-css-transitions',
+      location:
+        'https://johnnyreilly.com/simple-fading-in-and-out-using-css-transitions',
     });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
       'x-ms-original-url: https://johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html to /simple-fading-in-and-out-using-css-transitions'
+      'Redirecting https://johnnyreilly.com/2013/12/simple-fading-in-and-out-using-css-transitions.html to https://johnnyreilly.com/simple-fading-in-and-out-using-css-transitions'
     );
   });
 
@@ -56,14 +79,14 @@ describe('redirect', () => {
       )
     ).toEqual({
       status: 301,
-      location: '/rss.xml',
+      location: 'https://johnnyreilly.com/rss.xml',
     });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
       'x-ms-original-url: https://johnnyreilly.com/feeds/posts/default?alt=rss'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://johnnyreilly.com/feeds/posts/default?alt=rss to /rss.xml'
+      'Redirecting https://johnnyreilly.com/feeds/posts/default?alt=rss to https://johnnyreilly.com/rss.xml'
     );
   });
 
@@ -74,14 +97,14 @@ describe('redirect', () => {
       redirect('https://johnnyreilly.com/feeds/posts/default', mockLogger)
     ).toEqual({
       status: 301,
-      location: '/atom.xml',
+      location: 'https://johnnyreilly.com/atom.xml',
     });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
       'x-ms-original-url: https://johnnyreilly.com/feeds/posts/default'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://johnnyreilly.com/feeds/posts/default to /atom.xml'
+      'Redirecting https://johnnyreilly.com/feeds/posts/default to https://johnnyreilly.com/atom.xml'
     );
   });
 
@@ -92,14 +115,14 @@ describe('redirect', () => {
       redirect('https://johnnyreilly.com/search/label/uglifyjs', mockLogger)
     ).toEqual({
       status: 301,
-      location: '/search?q=uglifyjs',
+      location: 'https://johnnyreilly.com/search?q=uglifyjs',
     });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
       'x-ms-original-url: https://johnnyreilly.com/search/label/uglifyjs'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://johnnyreilly.com/search/label/uglifyjs to /search?q=uglifyjs'
+      'Redirecting https://johnnyreilly.com/search/label/uglifyjs to https://johnnyreilly.com/search?q=uglifyjs'
     );
   });
 
@@ -108,14 +131,14 @@ describe('redirect', () => {
 
     expect(redirect('https://johnnyreilly.com/2020/12/', mockLogger)).toEqual({
       status: 301,
-      location: '/archive',
+      location: 'https://johnnyreilly.com/archive',
     });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
       'x-ms-original-url: https://johnnyreilly.com/2020/12/'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://johnnyreilly.com/2020/12/ to /archive'
+      'Redirecting https://johnnyreilly.com/2020/12/ to https://johnnyreilly.com/archive'
     );
   });
 
@@ -124,14 +147,14 @@ describe('redirect', () => {
 
     expect(redirect('https://johnnyreilly.com/2020/', mockLogger)).toEqual({
       status: 301,
-      location: '/archive',
+      location: 'https://johnnyreilly.com/archive',
     });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
       'x-ms-original-url: https://johnnyreilly.com/2020/'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://johnnyreilly.com/2020/ to /archive'
+      'Redirecting https://johnnyreilly.com/2020/ to https://johnnyreilly.com/archive'
     );
   });
 
@@ -146,14 +169,14 @@ describe('redirect', () => {
     ).toEqual({
       status: 301,
       location:
-        '/assets/images/robski-dynamic-auth-b50b7efd118b1c8ed1297a010749e0f4.webp',
+        'https://johnnyreilly.com/assets/images/robski-dynamic-auth-b50b7efd118b1c8ed1297a010749e0f4.webp',
     });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
       'x-ms-original-url: https://johnnyreilly.com/assets/images/robski-dynamic-auth-9ac401590462e2bece9156353b92d187.png'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://johnnyreilly.com/assets/images/robski-dynamic-auth-9ac401590462e2bece9156353b92d187.png to /assets/images/robski-dynamic-auth-b50b7efd118b1c8ed1297a010749e0f4.webp'
+      'Redirecting https://johnnyreilly.com/assets/images/robski-dynamic-auth-9ac401590462e2bece9156353b92d187.png to https://johnnyreilly.com/assets/images/robski-dynamic-auth-b50b7efd118b1c8ed1297a010749e0f4.webp'
     );
   });
 
@@ -162,11 +185,11 @@ describe('redirect', () => {
 
     expect(redirect('', mockLogger)).toEqual({
       status: 302,
-      location: '/404',
+      location: 'https://johnnyreilly.com/404',
     });
 
     expect(mockLogger.mock.calls[0][0]).toBe(
-      'Redirecting  to /404 as no explicit redirect exists'
+      'Redirecting  to https://johnnyreilly.com/404 as no explicit redirect exists'
     );
   });
 
@@ -177,7 +200,7 @@ describe('redirect', () => {
       {
         status: 302,
         location:
-          '/404?originalUrl=https%3A%2F%2Fjohnnyreilly.com%2Frobots.txt',
+          'https://johnnyreilly.com/404?originalUrl=https%3A%2F%2Fjohnnyreilly.com%2Frobots.txt',
       }
     );
 
@@ -185,7 +208,7 @@ describe('redirect', () => {
       'x-ms-original-url: https://johnnyreilly.com/robots.txt'
     );
     expect(mockLogger.mock.calls[1][0]).toBe(
-      'Redirecting https://johnnyreilly.com/robots.txt to /404?originalUrl=https%3A%2F%2Fjohnnyreilly.com%2Frobots.txt as no explicit redirect exists'
+      'Redirecting https://johnnyreilly.com/robots.txt to https://johnnyreilly.com/404?originalUrl=https%3A%2F%2Fjohnnyreilly.com%2Frobots.txt as no explicit redirect exists'
     );
   });
 });


### PR DESCRIPTION
This PR moves the redirect mechanism to redirect only once, and to fully qualified URLs.  Aligned with this, we'll also remove the redirect from blog.johnnyreilly.com -> johnnyreilly.com that sits in Cloudflare.

Because Bicep deployments are broken; see: https://github.com/Azure/azure-cli/issues/25710 - they are commented out for now.