### PR TITLE
feat: migrate examples from ::set-output -> >> $GITHUB_OUTPUT

### DIFF
--- a/blog-website/blog/2021-12-27-azure-container-apps-build-and-deploy-with-bicep-and-github-actions/index.md
+++ b/blog-website/blog/2021-12-27-azure-container-apps-build-and-deploy-with-bicep-and-github-actions/index.md
@@ -461,7 +461,11 @@ jobs:
 
       - name: Output image tag
         id: image-tag
-        run: echo "::set-output name=image-${{ matrix.services.imageName }}::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.services.imageName }}:sha-$(git rev-parse --short HEAD)" | tr '[:upper:]' '[:lower:]'
+        run: |
+          name=$(echo "image-${{ matrix.services.imageName }}" | tr '[:upper:]' '[:lower:]')
+          value=$(echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.services.imageName }}:sha-$(git rev-parse --short HEAD)" | tr '[:upper:]' '[:lower:]')
+          echo "setting output: $name=$value"
+          echo "$name=$value" >> $GITHUB_OUTPUT
 
   deploy:
     runs-on: ubuntu-latest

--- a/blog-website/blog/2021-12-28-azure-cli-show-query-output-properties/index.md
+++ b/blog-website/blog/2021-12-28-azure-cli-show-query-output-properties/index.md
@@ -90,6 +90,6 @@ echo $DEPLOYMENT_OUTPUTS | jq -c '. | to_entries[] | [.key, .value.value]' |
     OUTPUT_NAME=$(echo "$c" | jq -r '.[0]')
     OUTPUT_VALUE=$(echo "$c" | jq -r '.[1]')
     echo "setting output $OUTPUT_NAME=$OUTPUT_VALUE"
-    echo "::set-output name=$OUTPUT_NAME::$OUTPUT_VALUE"
+    echo "$OUTPUT_NAME=$OUTPUT_VALUE" >> $GITHUB_OUTPUT
   done
 ```

--- a/blog-website/blog/2022-01-22-azure-container-apps-dapr-bicep-github-actions-debug-devcontainer/index.md
+++ b/blog-website/blog/2022-01-22-azure-container-apps-dapr-bicep-github-actions-debug-devcontainer/index.md
@@ -908,7 +908,11 @@ jobs:
 
       - name: Output image tag
         id: image-tag
-        run: echo "::set-output name=image-${{ matrix.services.imageName }}::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.services.imageName }}:sha-$(git rev-parse --short HEAD)" | tr '[:upper:]' '[:lower:]'
+        run: |
+          name=$(echo "image-${{ matrix.services.imageName }}" | tr '[:upper:]' '[:lower:]')
+          value=$(echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.services.imageName }}:sha-$(git rev-parse --short HEAD)" | tr '[:upper:]' '[:lower:]')
+          echo "setting output: $name=$value"
+          echo "$name=$value" >> $GITHUB_OUTPUT
 
   deploy:
     runs-on: ubuntu-latest

--- a/blog-website/blog/2022-12-18-azure-static-web-apps-build-app-externally/index.md
+++ b/blog-website/blog/2022-12-18-azure-static-web-apps-build-app-externally/index.md
@@ -29,7 +29,7 @@ Let's start by looking at a simple Azure Static Web Apps configuration:
   with:
     inlineScript: |
       APIKEY=$(az staticwebapp secrets list --name '${{ env.STATICWEBAPPNAME }}' | jq -r '.properties.apiKey')
-      echo "::set-output name=APIKEY::$APIKEY"
+      echo "APIKEY=$APIKEY" >> $GITHUB_OUTPUT
 
 - name: Static Web App - build and deploy
   id: static_web_app_build_and_deploy
@@ -58,7 +58,7 @@ So, I decided to build the app externally and then deploy it. I did this by twea
   with:
     inlineScript: |
       APIKEY=$(az staticwebapp secrets list --name '${{ env.STATICWEBAPPNAME }}' | jq -r '.properties.apiKey')
-      echo "::set-output name=APIKEY::$APIKEY"
+      echo "APIKEY=$APIKEY" >> $GITHUB_OUTPUT
 
 - name: Setup Node.js 🔧
   uses: actions/setup-node@v3

--- a/blog-website/blog/2023-02-01-migrating-from-github-pages-to-azure-static-web-apps/index.md
+++ b/blog-website/blog/2023-02-01-migrating-from-github-pages-to-azure-static-web-apps/index.md
@@ -184,7 +184,7 @@ jobs:
         run: |
           REF_SHA='${{ github.ref }}.${{ github.sha }}'
           DEPLOYMENT_NAME="${REF_SHA////-}"
-          echo "::set-output name=DEPLOYMENT_NAME::$DEPLOYMENT_NAME"
+          echo "DEPLOYMENT_NAME=$DEPLOYMENT_NAME" >> $GITHUB_OUTPUT
 
       - name: Static Web App - change details
         id: static_web_app_what_if
@@ -228,7 +228,7 @@ jobs:
         with:
           inlineScript: |
             APIKEY=$(az staticwebapp secrets list --name '${{ env.STATICWEBAPPNAME }}' | jq -r '.properties.apiKey')
-            echo "::set-output name=APIKEY::$APIKEY"
+            echo "APIKEY=$APIKEY" >> $GITHUB_OUTPUT
 
       - name: Static Web App - build and deploy
         id: static_web_app_build_and_deploy
@@ -255,7 +255,7 @@ jobs:
             PREVIEW_URL="https://${DEFAULTHOSTNAME/.[1-9]./-${{github.event.pull_request.number }}.${{ env.LOCATION }}.1.}"
             echo $PREVIEW_URL
 
-            echo "::set-output name=PREVIEW_URL::$PREVIEW_URL"
+            echo "PREVIEW_URL=$PREVIEW_URL" >> $GITHUB_OUTPUT
 
     outputs:
       preview-url: ${{steps.static_web_app_preview_url.outputs.PREVIEW_URL}}
@@ -276,7 +276,7 @@ jobs:
         with:
           inlineScript: |
             APIKEY=$(az staticwebapp secrets list --name '${{ env.STATICWEBAPPNAME }}' | jq -r '.properties.apiKey')
-            echo "::set-output name=APIKEY::$APIKEY"
+            echo "APIKEY=$APIKEY" >> $GITHUB_OUTPUT
 
       - name: Close Pull Request
         id: closepullrequest


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/