### PR TITLE
fix: jq not around use tsv

### DIFF
--- a/.github/workflows/build-and-deploy-static-web-app.yml
+++ b/.github/workflows/build-and-deploy-static-web-app.yml
@@ -181,7 +181,8 @@ jobs:
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            APIKEY=$(az staticwebapp secrets list --name '${{ env.STATIC_WEB_APP_NAME }}' | jq -r '.properties.apiKey')
+            # APIKEY=$(az staticwebapp secrets list --name '${{ env.STATIC_WEB_APP_NAME }}' | jq -r '.properties.apiKey')
+            APIKEY=$(az staticwebapp secrets list --name '${{ env.STATIC_WEB_APP_NAME }}' --query properties.apiKey -o tsv)
             echo "APIKEY=$APIKEY" >> $GITHUB_OUTPUT
 
       - name: Deploy site 🚀
@@ -411,7 +412,8 @@ jobs:
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            APIKEY=$(az staticwebapp secrets list --name '${{ env.STATIC_WEB_APP_NAME }}' | jq -r '.properties.apiKey')
+            # APIKEY=$(az staticwebapp secrets list --name '${{ env.STATIC_WEB_APP_NAME }}' | jq -r '.properties.apiKey')
+            APIKEY=$(az staticwebapp secrets list --name '${{ env.STATIC_WEB_APP_NAME }}' --query properties.apiKey -o tsv)
             echo "APIKEY=$APIKEY" >> $GITHUB_OUTPUT
 
       - name: Destroy staging environment 💥

--- a/.github/workflows/build-and-deploy-static-web-app.yml
+++ b/.github/workflows/build-and-deploy-static-web-app.yml
@@ -57,6 +57,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: azure/CLI@v2
         with:
+          azcliversion: 2.63.0 # pinning because https://github.com/Azure/cli/issues/165
           inlineScript: |
             az version
             az bicep install
@@ -88,6 +89,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: azure/CLI@v2
         with:
+          azcliversion: 2.63.0 # pinning because https://github.com/Azure/cli/issues/165
           inlineScript: |
             az deployment group what-if \
               --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
@@ -180,6 +182,7 @@ jobs:
         id: static_web_app_apikey
         uses: azure/CLI@v2
         with:
+          azcliversion: 2.63.0 # pinning because https://github.com/Azure/cli/issues/165
           inlineScript: |
             # APIKEY=$(az staticwebapp secrets list --name '${{ env.STATIC_WEB_APP_NAME }}' | jq -r '.properties.apiKey')
             APIKEY=$(az staticwebapp secrets list --name '${{ env.STATIC_WEB_APP_NAME }}' --query properties.apiKey -o tsv)
@@ -214,6 +217,7 @@ jobs:
         id: static_web_app_preview_url
         uses: azure/CLI@v2
         with:
+          azcliversion: 2.63.0 # pinning because https://github.com/Azure/cli/issues/165
           inlineScript: |
             # DEFAULTHOSTNAME=$(az staticwebapp show -n '${{ env.STATIC_WEB_APP_NAME }}' | jq -r '.defaultHostname')
             DEFAULTHOSTNAME=$(az staticwebapp show -n '${{ env.STATIC_WEB_APP_NAME }}' --query defaultHostname -o tsv)
@@ -412,6 +416,7 @@ jobs:
         id: apikey
         uses: azure/CLI@v2
         with:
+          azcliversion: 2.63.0 # pinning because https://github.com/Azure/cli/issues/165
           inlineScript: |
             # APIKEY=$(az staticwebapp secrets list --name '${{ env.STATIC_WEB_APP_NAME }}' | jq -r '.properties.apiKey')
             APIKEY=$(az staticwebapp secrets list --name '${{ env.STATIC_WEB_APP_NAME }}' --query properties.apiKey -o tsv)

--- a/.github/workflows/build-and-deploy-static-web-app.yml
+++ b/.github/workflows/build-and-deploy-static-web-app.yml
@@ -215,7 +215,8 @@ jobs:
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            DEFAULTHOSTNAME=$(az staticwebapp show -n '${{ env.STATIC_WEB_APP_NAME }}' | jq -r '.defaultHostname')
+            # DEFAULTHOSTNAME=$(az staticwebapp show -n '${{ env.STATIC_WEB_APP_NAME }}' | jq -r '.defaultHostname')
+            DEFAULTHOSTNAME=$(az staticwebapp show -n '${{ env.STATIC_WEB_APP_NAME }}' --query defaultHostname -o tsv)
 
             PREVIEW_URL="https://${DEFAULTHOSTNAME/.[1-9]./-${{github.event.pull_request.number }}.${{ env.AZURE_LOCATION }}.1.}"
 


### PR DESCRIPTION
- jq will not be available anymore; use tsv
- pin to specific AZ CLI version 2.63.0 because new image has issues affecting Bicep https://github.com/Azure/cli/issues/165

The underlying cause of the error is a changed base image:

> As announced in https://learn.microsoft.com/en-us/cli/azure/run-azure-cli-docker, the image base of Azure CLI 2.64.0 has changed from Alpine to CBL Mariner 2.0. This change may introduce some breaking changes that could cause failures in bicep. We will investigate this issue during our work hours.

from: https://github.com/Azure/azure-cli/issues/29828#issuecomment-2326693017

I suspect this was also the thing that broke jq usage in my pipelines - jq is not on the new image.  Quite frustrating given this was not officially a breaking change for the Azure CLI running in a Docker container, but is actually a breaking change.